### PR TITLE
Combined PR for Improvement and NPE fix

### DIFF
--- a/src/main/java/com/jnngl/vanillaminimaps/VanillaMinimaps.java
+++ b/src/main/java/com/jnngl/vanillaminimaps/VanillaMinimaps.java
@@ -197,12 +197,12 @@ public final class VanillaMinimaps extends JavaPlugin implements MinimapProvider
 
   @Override
   public Minimap getPlayerMinimap(Player player) {
-    return minimapListener.getPlayerMinimaps().get(player);
+    return minimapListener.getPlayerMinimaps().get(player.getUniqueId());
   }
 
   @Override
   public FullscreenMinimap getFullscreenMinimap(Player player) {
-    return minimapListener.getFullscreenMinimaps().get(player);
+    return minimapListener.getFullscreenMinimaps().get(player.getUniqueId());
   }
 
   public PassengerRewriter getPassengerRewriter(Player player) {

--- a/src/main/java/com/jnngl/vanillaminimaps/listener/MinimapListener.java
+++ b/src/main/java/com/jnngl/vanillaminimaps/listener/MinimapListener.java
@@ -52,11 +52,11 @@ import java.util.*;
 public class MinimapListener implements Listener {
 
   @Getter
-  private final Map<Player, Minimap> playerMinimaps = new HashMap<>();
+  private final Map<UUID, Minimap> playerMinimaps = new HashMap<>();
   @Getter
-  private final Map<Player, FullscreenMinimap> fullscreenMinimaps = new HashMap<>();
-  private final Map<Player, SteerableLockedView> lockedViews = new HashMap<>();
-  private final Map<Player, IntIntImmutablePair> playerSections = new HashMap<>();
+  private final Map<UUID, FullscreenMinimap> fullscreenMinimaps = new HashMap<>();
+  private final Map<UUID, SteerableLockedView> lockedViews = new HashMap<>();
+  private final Map<UUID, IntIntImmutablePair> playerSections = new HashMap<>();
   private final Set<UUID> requestedUpdates = new HashSet<>();
   private final VanillaMinimaps plugin;
 
@@ -76,8 +76,8 @@ public class MinimapListener implements Listener {
   }
 
   public Minimap enableMinimap(Player player) {
-    if (playerMinimaps.containsKey(player)) {
-      return playerMinimaps.get(player);
+    if (playerMinimaps.containsKey(player.getUniqueId())) {
+      return playerMinimaps.get(player.getUniqueId());
     }
 
     ClientsideMinimapFactory minimapFactory = plugin.clientsideMinimapFactory();
@@ -87,7 +87,7 @@ public class MinimapListener implements Listener {
     Minimap minimap = minimapFactory.createMinimap(player, Config.instance().defaultPosition, worldRenderer);
     packetSender.spawnMinimap(minimap);
 
-    playerMinimaps.put(player, minimap);
+    playerMinimaps.put(player.getUniqueId(), minimap);
 
     MinimapIcon playerIcon = plugin.iconProvider().getIcon("player");
     MinimapIcon offscreenPlayerIcon = plugin.iconProvider().getIcon("offscreen_player");
@@ -119,8 +119,8 @@ public class MinimapListener implements Listener {
   }
 
   public void disableMinimap(Player player) {
-    playerSections.remove(player);
-    Minimap minimap = playerMinimaps.remove(player);
+    playerSections.remove(player.getUniqueId());
+    Minimap minimap = playerMinimaps.remove(player.getUniqueId());
     if (minimap != null) {
       MinimapLayerRenderer primaryRenderer = minimap.primaryLayer().renderer();
       if (primaryRenderer instanceof CacheableWorldMinimapRenderer cacheableRenderer) {
@@ -136,19 +136,19 @@ public class MinimapListener implements Listener {
     SteerableLockedView view = plugin.steerableViewFactory().lockedView(minimap.getHolder());
     minimap.spawn(plugin);
 
-    fullscreenMinimaps.put(minimap.getHolder(), minimap);
-    lockedViews.put(minimap.getHolder(), view);
+    fullscreenMinimaps.put(minimap.getHolder().getUniqueId(), minimap);
+    lockedViews.put(minimap.getHolder().getUniqueId(), view);
 
     return view;
   }
 
   public void closeFullscreen(Player player) {
-    SteerableLockedView view = lockedViews.remove(player);
+    SteerableLockedView view = lockedViews.remove(player.getUniqueId());
     if (view != null) {
       view.destroy();
     }
 
-    FullscreenMinimap fullscreenMinimap = fullscreenMinimaps.remove(player);
+    FullscreenMinimap fullscreenMinimap = fullscreenMinimaps.remove(player.getUniqueId());
     if (fullscreenMinimap != null) {
       fullscreenMinimap.despawn(plugin, null);
     }
@@ -160,7 +160,7 @@ public class MinimapListener implements Listener {
       return;
     }
 
-    Minimap minimap = playerMinimaps.get(event.getPlayer());
+    Minimap minimap = playerMinimaps.get(event.getPlayer().getUniqueId());
     if (minimap == null) {
       return;
     }
@@ -182,25 +182,25 @@ public class MinimapListener implements Listener {
       return;
     }
 
-    Minimap minimap = playerMinimaps.get(event.getPlayer());
+    Minimap minimap = playerMinimaps.get(event.getPlayer().getUniqueId());
     if (minimap == null) {
       return;
     }
 
-    IntIntImmutablePair previous = playerSections.get(event.getPlayer());
+    IntIntImmutablePair previous = playerSections.get(event.getPlayer().getUniqueId());
     int currentX = event.getTo().getBlockX() >> 7;
     int currentZ = event.getTo().getBlockZ() >> 7;
     boolean changedSection = previous == null || currentZ != previous.rightInt() || currentX != previous.leftInt();
     minimap.update(plugin, event.getTo().getX(), event.getTo().getZ(), changedSection);
     requestedUpdates.remove(event.getPlayer().getUniqueId());
     if (changedSection) {
-      playerSections.put(event.getPlayer(), IntIntImmutablePair.of(currentX, currentZ));
+      playerSections.put(event.getPlayer().getUniqueId(), IntIntImmutablePair.of(currentX, currentZ));
     }
   }
 
   @EventHandler
   public void onRespawn(PlayerPostRespawnEvent event) {
-    Minimap minimap = playerMinimaps.get(event.getPlayer());
+    Minimap minimap = playerMinimaps.get(event.getPlayer().getUniqueId());
     if (minimap == null) {
       return;
     }
@@ -210,7 +210,7 @@ public class MinimapListener implements Listener {
 
   @EventHandler
   public void onWorldChange(PlayerChangedWorldEvent event) {
-    Minimap minimap = playerMinimaps.get(event.getPlayer());
+    Minimap minimap = playerMinimaps.get(event.getPlayer().getUniqueId());
     if (minimap == null) {
       return;
     }
@@ -223,7 +223,7 @@ public class MinimapListener implements Listener {
   public void onQuit(PlayerQuitEvent event) {
     Bukkit.getScheduler().scheduleSyncDelayedTask(plugin, () ->
         disableMinimap(event.getPlayer()));
-    Minimap minimap = playerMinimaps.get(event.getPlayer());
+    Minimap minimap = playerMinimaps.get(event.getPlayer().getUniqueId());
     plugin.playerDataStorage().save(minimap);
   }
 }

--- a/src/main/java/com/jnngl/vanillaminimaps/listener/MinimapListener.java
+++ b/src/main/java/com/jnngl/vanillaminimaps/listener/MinimapListener.java
@@ -48,6 +48,7 @@ import org.bukkit.event.player.PlayerMoveEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 
 import java.util.*;
+import org.jetbrains.annotations.Nullable;
 
 public class MinimapListener implements Listener {
 
@@ -118,7 +119,8 @@ public class MinimapListener implements Listener {
     return minimap;
   }
 
-  public void disableMinimap(Player player) {
+  @Nullable
+  public Minimap disableMinimap(Player player) {
     playerSections.remove(player.getUniqueId());
     Minimap minimap = playerMinimaps.remove(player.getUniqueId());
     if (minimap != null) {
@@ -130,6 +132,7 @@ public class MinimapListener implements Listener {
     }
 
     closeFullscreen(player);
+    return minimap;
   }
 
   public SteerableLockedView openFullscreen(FullscreenMinimap minimap) {
@@ -221,9 +224,11 @@ public class MinimapListener implements Listener {
   @SneakyThrows
   @EventHandler
   public void onQuit(PlayerQuitEvent event) {
-    Bukkit.getScheduler().scheduleSyncDelayedTask(plugin, () ->
-        disableMinimap(event.getPlayer()));
-    Minimap minimap = playerMinimaps.get(event.getPlayer().getUniqueId());
-    plugin.playerDataStorage().save(minimap);
+    Minimap minimap = disableMinimap(event.getPlayer());
+
+    // minimap can be null if player has it disabled
+    if (minimap != null) {
+      plugin.playerDataStorage().save(minimap);
+    }
   }
 }


### PR DESCRIPTION
In two commits I've changed the following things:

- I use the players UUID in the minimap map instead of the Player object. This reduces the memory footprint and helps preventing memory leaks (unlikely but can happen for whatever reason)
- I fixed an NPE for players that have the minimap disabled and log out

If needed i can split this PR into two.

Kind regards
Alex