### PR TITLE
WIP : Attempt to change zoom level of the minimap

### DIFF
--- a/src/main/java/com/jnngl/vanillaminimaps/map/Minimap.java
+++ b/src/main/java/com/jnngl/vanillaminimaps/map/Minimap.java
@@ -72,14 +72,14 @@ public final class Minimap {
         offsetZ += 128;
       }
       byte[] data = cacheableRenderer.getWorldMapCache().get(holder.getWorld(), alignedX, alignedZ);
-      byte[] dataRight = cacheableRenderer.getWorldMapCache().get(holder.getWorld(), alignedX + 128, alignedZ);
-      byte[] dataUpRight = cacheableRenderer.getWorldMapCache().get(holder.getWorld(), alignedX + 128, alignedZ + 128);
-      byte[] dataUp = cacheableRenderer.getWorldMapCache().get(holder.getWorld(), alignedX, alignedZ + 128);
+      byte[] dataRight = cacheableRenderer.getWorldMapCache().get(holder.getWorld(), alignedX + 256, alignedZ);
+      byte[] dataUpRight = cacheableRenderer.getWorldMapCache().get(holder.getWorld(), alignedX + 256, alignedZ + 256);
+      byte[] dataUp = cacheableRenderer.getWorldMapCache().get(holder.getWorld(), alignedX, alignedZ + 256);
       LongList usedChunks = LongList.of(
           WorldMapCache.getKey(holder.getWorld(), alignedTrackX, alignedTrackZ),
-          WorldMapCache.getKey(holder.getWorld(), alignedTrackX + 128, alignedTrackZ),
-          WorldMapCache.getKey(holder.getWorld(), alignedTrackX + 128, alignedTrackZ + 128),
-          WorldMapCache.getKey(holder.getWorld(), alignedTrackX, alignedTrackZ + 128)
+          WorldMapCache.getKey(holder.getWorld(), alignedTrackX + 256, alignedTrackZ),
+          WorldMapCache.getKey(holder.getWorld(), alignedTrackX + 256, alignedTrackZ + 256),
+          WorldMapCache.getKey(holder.getWorld(), alignedTrackX, alignedTrackZ + 256)
       );
       for (int z = 0; z < 128; z++) {
         for (int x = 0; x < 128; x++) {

--- a/src/main/java/com/jnngl/vanillaminimaps/map/renderer/world/FlatWorldMinimapRenderer.java
+++ b/src/main/java/com/jnngl/vanillaminimaps/map/renderer/world/FlatWorldMinimapRenderer.java
@@ -24,24 +24,36 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.MapColor;
+import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.craftbukkit.v1_20_R3.block.CraftBlock;
 import org.bukkit.craftbukkit.v1_20_R3.block.data.CraftBlockData;
+
+import java.util.ArrayList;
+import java.util.Collections;
 
 public class FlatWorldMinimapRenderer implements CacheableWorldMinimapRenderer {
 
   private final WorldMapCache<FlatWorldMinimapRenderer> cache = new WorldMapCache<>(this);
 
   @Override
-  public void renderFully(World world, int blockX, int blockZ, byte[] data) {
-    for (int x = 0; x < 128; x++) {
-      for (int z = 0; z < 128; z++) {
-        int worldX = blockX + x;
-        int worldZ = blockZ + z;
-        int index = (127 - z) * 128 + (127 - x);
+  public void renderFully(World world, int centerX, int centerZ, byte[] data) {
+
+    int size = 256;
+    int step = (int) (size/128.0);
+
+    for (int x = 0; x < size; x+= step) {
+      for (int z = 0; z < size; z+= step) {
+
+        int worldX = centerX + x;
+        int worldZ = centerZ + z;
+
+        int index = (int) ((127 - z/step) * 128 + (127 - x/step));
+
         Block block = world.getHighestBlockAt(worldX, worldZ);
         storeBlockColor(data, index, block);
+
       }
     }
   }


### PR DESCRIPTION
I want to change the zoom level of the minimap (like the vanilla way) meaning each pixel don't represent one block but, for example, four.

For now, I changed the way the flat render work, the minimap is scaled down the way I want, but I have an issue with player movement. 
The minimap scrolling still goes at the same speed as the player, when it's a 1:1 ratio it's not an issue, but now it's a 1:2 ratio and it glitches out. When I go to the end of a 1:1 classic section of the world (a 128x128 zone) the visual snap to the beginning of the section and everything end-up is misaligned.

I hope someone can figure out how to fix the move part, I tried a lot of things, but everything broke 😞

Known issue : Since we are pulling blocks from a 256 by 256 zone (16*16 chunks) instead of 128 by 128 zone (8 by 8 chunks) everything is slower and the performances are way worst but it "normal"